### PR TITLE
Add support for Kiwi browser

### DIFF
--- a/static/fromEntries-polyfill.js
+++ b/static/fromEntries-polyfill.js
@@ -1,0 +1,3 @@
+/*! fromentries. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
+// Based on work from https://github.com/feross/fromentries/blob/master/index.js
+Object.prototype.fromEntries || Object.defineProperty(Object.prototype, "fromEntries", { configurable: !0, value: function(iterable) { return [...iterable].reduce((obj, [key, val]) => { obj[key] = val; return obj; }, {})}, writable: !0});

--- a/static/fromEntries-polyfill.js
+++ b/static/fromEntries-polyfill.js
@@ -1,3 +1,4 @@
 /*! fromentries. MIT License. Feross Aboukhadijeh <https://feross.org/opensource> */
+// This file is required for the extension to work on Kiwi browser.
 // Based on work from https://github.com/feross/fromentries/blob/master/index.js
 Object.prototype.fromEntries || Object.defineProperty(Object.prototype, "fromEntries", { configurable: !0, value: function(iterable) { return [...iterable].reduce((obj, [key, val]) => { obj[key] = val; return obj; }, {})}, writable: !0});

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -13,11 +13,11 @@
     "128": "icons/128.png" 
   },
   "background": {
-    "scripts": ["background.js"]
+    "scripts": ["fromEntries-polyfill.js", "background.js"]
   },
   "content_scripts": [{
     "matches": ["https://*/*", "http://*/*", "file://*/*"],
-    "js": ["contentScript.js"],
+    "js": ["fromEntries-polyfill.js", "contentScript.js"],
     "all_frames": true,
     "run_at": "document_start"
   }],

--- a/static/options.html
+++ b/static/options.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="fromEntries-polyfill.js"></script>
     <script src="options.js"></script>
   </body>
 </html> 

--- a/static/popup.html
+++ b/static/popup.html
@@ -5,6 +5,7 @@
   </head>
   <body>
     <div id="root"></div>
+    <script src="fromEntries-polyfill.js"></script>
     <script src="popup.js"></script>
   </body>
 </html> 


### PR DESCRIPTION
Added Object.fromEntries polyfill to relevant places so the extension would work on Kiwi browser. 

Kiwi browser uses the same V8 version as Chrome 68(even though other parts of the browser are based on 77), but Object.fromEntries was introduced in the V8 version that came with Chrome 73