### PR TITLE
feat: new speed `adjustMode` for Non-Cycle speed values (list).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3689,9 +3689,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
-      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "peerDependencies": {
         "react": "*"
       }
@@ -7040,9 +7040,9 @@
       }
     },
     "react-icons": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.7.1.tgz",
-      "integrity": "sha512-yHd3oKGMgm7zxo3EA7H2n7vxSoiGmHk5t6Ou4bXsfcgWyhfDKMpyKfhHR6Bjnn63c+YXBLBPUql9H4wPJM6sXw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.12.0.tgz",
+      "integrity": "sha512-IBaDuHiShdZqmfc/TwHu6+d6k2ltNCf3AszxNmjJc1KUfXdEeRJOKyNvLmAHaarhzGmTSVygNdyu8/opXv2gaw==",
       "requires": {}
     },
     "rechoir": {

--- a/src/options/KeyBindControl.tsx
+++ b/src/options/KeyBindControl.tsx
@@ -6,10 +6,11 @@ import { Tooltip } from "../comps/Tooltip"
 import { NumericInput } from "../comps/NumericInput"
 import { commandInfos } from "../defaults/commands"
 import { filterInfos, FilterName, filterTargets  } from "../defaults/filters"
-import { GoChevronDown, GoChevronUp, GoX, GoTriangleDown, GoCode, GoPin, GoZap, GoKebabVertical } from "react-icons/go"
+import { GoChevronDown, GoChevronUp, GoX, GoTriangleDown, GoCode, GoPin, GoZap } from "react-icons/go"
 import { CycleInput } from "../comps/CycleInput"
 import { ModalText } from "../comps/ModalText"
 import { FaPowerOff, FaPause, FaEquals, FaBookmark, FaLink, FaVolumeUp, FaVolumeMute, FaGlobe, FaPercent, FaFile, FaBackward, FaForward, FaArrowRight, FaExchangeAlt, FaPlus, FaMusic, FaList, FaStar } from "react-icons/fa"
+import { PiArrowArcRightBold, PiArrowsClockwiseBold, PiDotsThreeOutlineVerticalFill } from "react-icons/pi"
 import { TbArrowsHorizontal } from "react-icons/tb"
 import { requestCreateTab } from "../utils/browserUtils"
 import { GiAnticlockwiseRotation } from "react-icons/gi"
@@ -249,11 +250,12 @@ export const KeybindControl = (props: KeybindControlProps) => {
         </>}
         {commandInfo.valueType === "adjustMode" && <button className="adjustMode" onClick={e => {
           props.onChange(value.id, produce(value, d => {
-            d.adjustMode = clamp(1, 3, ((d.adjustMode ?? 1) + 1) % 4)
+            d.adjustMode = clamp(1, 4, ((d.adjustMode ?? 1) + 1) % 5)
           }))
         }}>
             {value.adjustMode === AdjustMode.SET && <FaEquals size="1em"/>}
-            {value.adjustMode === AdjustMode.CYCLE && <FaList size="1em"/>}
+            {value.adjustMode === AdjustMode.CYCLE && <PiArrowsClockwiseBold size="1em"/>}
+            {value.adjustMode === AdjustMode.NOCYCLE && <PiArrowArcRightBold size="1em"/>}
             {value.adjustMode === AdjustMode.ADD && <FaPlus size="1em"/>}
         </button>}
       </div>
@@ -332,6 +334,13 @@ export const KeybindControl = (props: KeybindControlProps) => {
         }))
       }}/>
     )}
+    {commandInfo.valueType === "adjustMode" && value.adjustMode === AdjustMode.NOCYCLE && (
+      <CycleInput min={min} max={max} values={value.valueCycle || []} onChange={v => {
+        props.onChange(value.id, produce(value, d => {
+          d.valueCycle = v
+        }))
+      }}/>
+    )}
     {commandInfo.valueType === "string" && (
       <ThrottledTextInput passInput={specialKey ? {style: {color: "red"}} : undefined} value={value.valueString} onChange={v => {
         props.onChange(value.id, produce(value, d => {
@@ -360,7 +369,7 @@ export const KeybindControl = (props: KeybindControlProps) => {
     )}
     {!commandInfo.valueType && <div/>}
     <button className="icon" onClick={handleContextMenu}>
-      <GoKebabVertical style={{pointerEvents: "none"}} title="..." size="1.3em"/>
+      <PiDotsThreeOutlineVerticalFill style={{pointerEvents: "none"}} title="..." size="1.3em"/>
     </button>
     <button className="icon" onClick={e => {
        props.onChange(value.id, produce(value, d => {

--- a/src/popup/Header.tsx
+++ b/src/popup/Header.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react"
 import { checkFilterDeviation } from "../utils/configUtils"
-import { GoPin, GoGear, GoMarkGithub, GoZap, GoArrowLeft} from "react-icons/go"
-import { FaPowerOff, FaVolumeUp } from "react-icons/fa"
+import { GoPin, GoGear, GoZap, GoArrowLeft} from "react-icons/go"
+import { FaPowerOff, FaVolumeUp, FaGithub } from "react-icons/fa"
 import { useStateView } from "../hooks/useStateView"
 import { pushView } from "../background/GlobalState"
 import { getDefaultFx } from "../defaults"
@@ -63,7 +63,7 @@ export function Header(props: HeaderProps) {
       <div title="open github page." onClick={e => {
         window.open("https://github.com/polywock/globalSpeed", "_blank")
       }}>
-        <GoMarkGithub size="18px"/>
+        <FaGithub size="18px"/>
       </div>
     </div>
   )

--- a/src/types.ts
+++ b/src/types.ts
@@ -126,7 +126,8 @@ export type AudioFx = {
 export enum AdjustMode {
   SET = 1,
   ADD,
-  CYCLE
+  CYCLE,
+  NOCYCLE
 }
 
 export type Command = {


### PR DESCRIPTION
Can be paired with a reversed-ordered one manually by user, to achieve an ascending and descending bi-directional custom-level speed control, with two separate keybindings.

BREAKING CHANGE: upgrade `react-icons` from 4.7.1 to 4.12.0

# Detail
The most intuitive way is to separate key-binding field into two segments, one for ascending and the other for descending, The downside is that might introduce a lot of breaking changes to other components. (I'm not quite sure.)

Second way is to replicate a `KeyBind` (manually by user) for the existing speed `valueCycle` (precisely, `valueNoCycle`), acting as a reversed version of the other one, and vice versa. Also most importantly, ensure them stop iteration on their both boundaries. This implementation is quite simple, without sharing states between `KeyBind`s (e.g. `currentIndex`): When bound key was pressed, modify the playback speed to the nearest (but not same) speed level, within the corresponding ascend or descend direction—

Of course, if the user-defined `valueCycle` is either monotonically increasing or decreasing. Otherwise, user will be prompted an error.

However, this implementation doesn't force user-defined speed `valueCycle`s to be exactly the "same" (precisely, exactly opposite). This might be a benefit which allowing users to reduce playback speed more rapidly (by defining less steps in descending list), in order to be the coolest guy in the town.

Candidate icon pairs, for distinguishing NoCycle & Cycle:
[PiArrowArcRightBold](https://react-icons.github.io/react-icons/search/#q=PiArrowArcRightBold) & [PiArrowsClockwiseBold](https://react-icons.github.io/react-icons/search/#q=PiArrowsClockwiseBold) (This commit is using)
[TbArrowNarrowRight](https://react-icons.github.io/react-icons/search/#q=TbArrowNarrowRight) & [TbArrowAutofitRight](https://react-icons.github.io/react-icons/search/#q=TbArrowAutofitRight)
[CgArrowsShrinkV](https://react-icons.github.io/react-icons/search/#q=CgArrowsShrinkV) & [CgRedo](https://react-icons.github.io/react-icons/search/#q=CgRedo)
All of these need upgrading `react-icons` from "4.7.1" to "4.12.0"

(This is my first time learning to get involved in the Open Source world, so please forgive my grammar and wording, and I'm very appreciate for any advices.)

resolve: #158