### PR TITLE
fix(ConfigSync): add null checks to prevent undefined errors in keybi…

### DIFF
--- a/src/contentScript/isolated/ConfigSync.ts
+++ b/src/contentScript/isolated/ConfigSync.ts
@@ -108,10 +108,19 @@ export class ConfigSync {
     if (!chrome.runtime?.id) return gvar.os.handleOrphan()
     if (!this.client?.view) return 
     if (this.client.view.superDisable) return 
+
     const enabled = this.client.view.enabled
+    if (!this.client.view.keybinds) return
+
     let keybinds = this.client.view.keybinds
     if (!enabled) {
-      keybinds = this.client.view.keybinds.filter(kb => kb.command === "state" && kb.enabled && (kb.trigger || Trigger.LOCAL) === Trigger.LOCAL && (this.client.view.latestViaShortcut || kb.alwaysOn))
+      keybinds = this.client.view.keybinds?.filter(kb => 
+        kb?.command === "state" && 
+        kb?.enabled && 
+        (kb?.trigger || Trigger.LOCAL) === Trigger.LOCAL && 
+        (this.client.view?.latestViaShortcut || kb?.alwaysOn)
+      ) || []
+      
       if (!keybinds.length) return 
     }
 


### PR DESCRIPTION
Modification instructions:
Added early checks for this.client.view.keybinds
Added optional chain operator in the filter function To securely access object properties
Added | | [] as a fallback value to ensure that an empty array is returned when the filtering result is undefined
These modifications can prevent:
Accessing the undefined keybindings property
Accessing undefined object properties
Ensure that the filter operation always returns an array
This can avoid the error of 'Cannon read properties of undefined' while maintaining the integrity of the original functionality.