### PR TITLE
Fix global shortcut PiP when no active tab

### DIFF
--- a/src/background/utils/getAutoMedia.ts
+++ b/src/background/utils/getAutoMedia.ts
@@ -67,15 +67,14 @@ export async function getAutoMedia(tabInfo: TabInfo, videoOnly?: boolean) {
 
   infos.sort((a, b) => b.creationTime - a.creationTime)
   let pippedInfo = infos.find(info => info.pipMode) || infos.find(info => info.isDip)
-
   if (pippedInfo && !(await checkContentScript(pippedInfo.tabInfo.tabId, pippedInfo.tabInfo.frameId))) {
     pippedInfo = null
   }
 
   if (!ignorePiP && pippedInfo) return pippedInfo
-
-  if (!tabInfo) return (pippedInfo || undefined)
-  infos = infos.filter(info => info.tabInfo.tabId === tabInfo.tabId)
+  if (tabInfo) {
+    infos = infos.filter(info => info.tabInfo.tabId === tabInfo.tabId)
+  }
 
   if (!infos.length) return (pippedInfo || undefined)
 


### PR DESCRIPTION
This PR fixes a bug where the global shortcut for the `PiP` command sometimes fails to start Picture-in-Picture when Chrome does not provide an active tab to the `chrome.commands` handler.

Previously, `getAutoMedia` would return early when `tabInfo` was undefined, so in those cases no media element was selected and the `PiP` command did nothing. Now, when `tabInfo` is missing we still score all known media items and pick the best candidate, while continuing to respect pinned media and existing PiP when available.

Testing:

- Built the extension (`NODE_ENV=development npm run build:common`) and loaded it unpacked in Chrome.
- Configured `command A` as a global shortcut mapped to `PiP` with value state `toggle`.
- Verified that:
  - Global shortcut can toggle PiP off reliably in foreground and background.
  - Starting PiP via the global shortcut works more reliably than before even when there is no active tab passed to the command handler, and no longer fails just because `tabInfo` is missing.