### PR TITLE
Optimize temporary speed control with keyboard reset and shortcuts

### DIFF
--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -139,7 +139,7 @@ async function processNewTab(tab: chrome.tabs.Tab, view?: StateView, ignorePrevi
 			return true
 		})
 
-		new ProcessKeybinds(matches, tabInfo)
+		new ProcessKeybinds(matches, tabInfo, false, 'browser')
 	})
 
 chrome.contextMenus?.onClicked.addListener(async (item, tab) => {
@@ -157,7 +157,7 @@ declare global {
 		getTopOrigin: { type: "GET_TOP_ORIGIN" }
 		requestGsm: { type: "REQUEST_GSM" }
 		requestCreateTab: { type: "REQUEST_CREATE_TAB"; url: string }
-		triggerKeybinds: { type: "TRIGGER_KEYBINDS"; ids: KeybindMatchId[] }
+		triggerKeybinds: { type: "TRIGGER_KEYBINDS"; ids: KeybindMatchId[]; keyUp?: boolean }
 		requestPane: { type: "REQUEST_PANE" }
 		setSession: { type: "SET_SESSION"; override: AnyDict }
 		getSession: { type: "GET_SESSION"; keys: any }
@@ -214,7 +214,7 @@ chrome.runtime.onMessage.addListener((msg: Messages, sender, reply) => {
 					alt: v.alt,
 				} as KeybindMatch
 			})
-			new ProcessKeybinds(matches, { tabId: sender.tab.id, frameId: sender.frameId, windowId: sender.tab.windowId })
+			new ProcessKeybinds(matches, { tabId: sender.tab.id, frameId: sender.frameId, windowId: sender.tab.windowId }, !!msg.keyUp)
 		})
 		reply(true)
 	} else if (msg.type === "SET_SESSION") {

--- a/src/background/utils/processKeybinds.ts
+++ b/src/background/utils/processKeybinds.ts
@@ -40,6 +40,8 @@ export class ProcessKeybinds {
 	constructor(
 		private matches: KeybindMatch[],
 		public tabInfo: TabInfo,
+		public keyUp = false,
+		public source: 'keyboard' | 'browser' = 'keyboard',
 	) {
 		this.init()
 	}
@@ -126,7 +128,7 @@ export class ProcessKeybinds {
 
 		let override: StateView = {}
 		this.shortcutHideIndicator = kb.invertIndicator ? !this.globalHideIndicator : this.globalHideIndicator
-		await commandHandlers[kb.command]({ media, override, commandInfo, kb, isAlt: match.alt, ...this })
+		await commandHandlers[kb.command]({ media, override, commandInfo, kb, isAlt: match.alt, keyUp: this.keyUp, source: this.source, ...this })
 		if (Object.keys(override).length) await pushView({ override, tabId: this.tabInfo?.tabId })
 	}
 }
@@ -137,6 +139,7 @@ type CommandHandlerArgs = ProcessKeybinds & {
 	kb: Keybind
 	commandInfo: Command
 	isAlt?: boolean
+	source?: 'keyboard' | 'browser'
 }
 
 let nothingSymbolMap: { [key: string]: Symbol } = {}
@@ -282,10 +285,15 @@ const commandHandlers: {
 	speed: async (args) => {
 		return processAdjustMode(args)
 	},
-	temporarySpeed: async ({ media, show, kb, commandInfo }) => {
+	temporarySpeed: async ({ media, show, kb, commandInfo, keyUp, source }) => {
+		if (keyUp && source === 'keyboard') {
+			activateTemporarySpeed(media)
+			return
+		}
+
 		const factor = round(kb.valueNumber || commandInfo.ref.default, 2)
 		show({ text: `${factor}x` })
-		activateTemporarySpeed(media, factor)
+		activateTemporarySpeed(media, factor, source)
 	},
 	speedChangesPitch: async (args) => {
 		const { kb, show, override, fetch } = args
@@ -950,7 +958,14 @@ function showIndicator(opts: IndicatorShowOpts, tabId: number, showAlt?: boolean
 }
 
 let tempSpeedTimeoutId: number
-function activateTemporarySpeed(media: FlatMediaInfo, factor: number) {
+
+function activateTemporarySpeed(media: FlatMediaInfo, factor?: number, source: 'keyboard' | 'browser' = 'keyboard') {
+	if (factor === undefined) {
+		clearTimeout(tempSpeedTimeoutId)
+		chrome.tabs.sendMessage(media.tabInfo.tabId, { type: "SET_TEMPORARY_SPEED" } as Messages, { frameId: media.tabInfo.frameId })
+		return
+	}
+
 	chrome.tabs.sendMessage(
 		media.tabInfo.tabId,
 		{
@@ -959,15 +974,11 @@ function activateTemporarySpeed(media: FlatMediaInfo, factor: number) {
 		} as Messages,
 		{ frameId: media.tabInfo.frameId },
 	)
-	clearTimeout(tempSpeedTimeoutId)
 
-	tempSpeedTimeoutId = setTimeout(() => {
-		chrome.tabs.sendMessage(
-			media.tabInfo.tabId,
-			{
-				type: "SET_TEMPORARY_SPEED",
-			} as Messages,
-			{ frameId: media.tabInfo.frameId },
-		)
-	}, 150)
+	if (source === 'browser') {
+		clearTimeout(tempSpeedTimeoutId)
+		tempSpeedTimeoutId = setTimeout(() => {
+			activateTemporarySpeed(media)
+		}, 150)
+	}
 }

--- a/src/contentScript/isolated/ConfigSync.ts
+++ b/src/contentScript/isolated/ConfigSync.ts
@@ -207,6 +207,25 @@ export class ConfigSync {
 			e.stopImmediatePropagation()
 			e.preventDefault()
 		}
+
+		if (this.checkUrlRuntime() !== "Off") {
+			const eventHotkey = extractHotkey(e, true, true)
+			let keybinds = this.client?.view?.pageKeybinds || []
+			let matches = findMatchingPageKeybinds(keybinds, eventHotkey)
+
+			matches = matches.filter((match) => {
+				if (match.kb.condition && hasActiveParts(match.kb.condition)) {
+					return testURL(getPracticalRuntimeUrl(), match.kb.condition, true)
+				}
+				return true
+			})
+
+			matches = matches.filter((match) => match.kb.command === "temporarySpeed")
+
+			if (matches.length) {
+				chrome.runtime.sendMessage({ type: "TRIGGER_KEYBINDS", ids: matches.map((match) => ({ id: match.kb.id, alt: match.alt })), keyUp: true })
+			}
+		}
 	}
 	handleKeyDown = (e: KeyboardEvent) => {
 		if (document.activeElement?.tagName === "IFRAME") return


### PR DESCRIPTION
## GitHub PR Detailed Description

### 🎯 Problem Description

**Original Issue**: When long-pressing the speed-up shortcut key, it continuously sends speed setting messages, but due to keyboard event repetition or browser performance factors, the interval between message rounds may exceed 150ms, triggering the timeout reset mechanism, causing the speed-up to be intermittent and unable to maintain stable acceleration.

**Root Cause**:
- Original version used `setTimeout` 150ms timeout reset mechanism
- Keyboard events may cause intervals > 150ms due to system load or repetition
- Timeout reset conflicts with new messages, resulting in unstable experience

### 🔧 Solution

**Core Idea**: Change the reset mechanism from timeout-driven to event-driven, using `keyup` events for immediate reset. Also compatible with browser shortcuts (`chrome.commands` can only capture press, not release).

**Hybrid Strategy**:
- **Keyboard Shortcuts**: Press to activate → keyup immediate reset (no delay)
- **Browser Shortcuts**: Press to activate → 150ms timeout reset (maintain compatibility)

### 📝 Modified Content

#### 1. processKeybinds.ts
- **ProcessKeybinds Constructor**: Added `source: 'keyboard' | 'browser'` parameter
- **CommandHandlerArgs Type**: Added `source` field
- **temporarySpeed Command**:
  - On keyup, only `keyboard` source supports immediate reset
  - Pass `source` to `activateTemporarySpeed`
- **activateTemporarySpeed Function**:
  - Added `source` parameter
  - `keyboard` source: no timeout reset
  - `browser` source: 150ms timeout reset
  - Clear existing timeout on reset

#### 2. index.ts
- **chrome.commands.onCommand**: Pass `source: 'browser'` to ProcessKeybinds
- **TRIGGER_KEYBINDS**: Keep default `source: 'keyboard'`

#### 3. ConfigSync.ts
- **handleKeyUp**: Send keyup event to background for keybind processing

---

**Labels**: `enhancement`, `performance`, `user-experience`, `keyboard-shortcuts`